### PR TITLE
Dockerized Application

### DIFF
--- a/DOCKERFILE
+++ b/DOCKERFILE
@@ -1,0 +1,15 @@
+FROM node:10 as builder
+
+COPY . /app
+
+WORKDIR /app
+
+RUN npm install
+
+RUN $(npm bin)/ng build
+
+FROM nginx
+
+COPY --from=builder /app/dist/* /usr/share/nginx/html/
+
+EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,12 @@ WORKDIR /app
 
 RUN npm install
 
+RUN npm install --save-dev @angular/cli sass
+
 RUN $(npm bin)/ng build
 
 FROM nginx
 
-COPY --from=builder /app/dist/* /usr/share/nginx/html/
+COPY --from=builder /app/dist /usr/share/nginx/html
 
 EXPOSE 80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  web:
+    build: .
+    ports:
+      - "80:80"

--- a/src/.dockerignore
+++ b/src/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+npm-debug.log
+Dockerfile*
+docker-compose*
+.dockerignore
+.git
+.gitignore
+README.md
+LICENSE
+.vscode


### PR DESCRIPTION
 #29 Pull request content:

- Added support to use with `docker-compose up`.
- I didn't manage to skip node_modules when copy files to the build enviroment.
- Default port configured on docker-compose.yml is 80.

#### Make sure, node_modules is not in the folder, to prevent copying it to the build enviroment(it doesn't build that way).